### PR TITLE
Fix type error with RelectionExtractor

### DIFF
--- a/src/UltiproClient.php
+++ b/src/UltiproClient.php
@@ -182,7 +182,7 @@ class UltiproClient
                     );
                 }
 
-                $types = $reflectionExtractor->getTypes($responseClass, $property);
+                $types = $reflectionExtractor->getTypes(get_class($responseClass), $property);
                 $type  = $types[0];
 
                 if ($value && $type->getBuiltinType() === 'object' && $type->getClassName() === 'DateTime') {


### PR DESCRIPTION
ReflectionExtractor::getTypes($class) expects a string version of the
class. UltiproClient is passing an object. This wraps it in the
get_class() function.