### PR TITLE
Add level for org level query

### DIFF
--- a/src/Configuration/Query/OrgLevelQuery.php
+++ b/src/Configuration/Query/OrgLevelQuery.php
@@ -24,6 +24,9 @@ class OrgLevelQuery extends ConfigurationQuery
     private $code;
 
     /** @var string */
+    private $level;
+
+    /** @var string */
     private $budgetGroup;
 
     /** @var string */
@@ -68,6 +71,26 @@ class OrgLevelQuery extends ConfigurationQuery
     public function setCode(string $code)
     {
         $this->code = $code;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLevel()
+    {
+        return $this->level;
+    }
+
+    /**
+     * @param string $level
+     *
+     * @return OrgLevelQuery
+     */
+    public function setLevel(string $level)
+    {
+        $this->level = $level;
 
         return $this;
     }


### PR DESCRIPTION
Allow users to add a level to the organization level query so that they
can pull the code and the level or just all of the orgs for the level.