### PR TITLE
Handle Array Values on ReportsAsService

### DIFF
--- a/src/ReportsAsService/ReportClient.php
+++ b/src/ReportsAsService/ReportClient.php
@@ -287,6 +287,8 @@ class ReportClient extends UltiproSoapClient
             $data = [];
 
             foreach ($row['value'] as $key => $value) {
+                $value = is_array($value) ? implode(" | ", array_map("trim", array_filter($value))) : trim($value);
+
                 $data[$reportArray['metadata']['item'][$key]['@attributes']['name']] = trim($value);
             }
 


### PR DESCRIPTION
It appears that when there is no data in a column, the API returns the value as an empty array. The code breaks when it tries to `trim` the array. We can assume that the results could be an array of values based on that returned type when it's empty, so we're going to handle array values by `imploding them into a pipe-separated list, and trimming the values with an `array_map` inside the `implode`.