### PR TITLE
Defer SOAP Client Building

### DIFF
--- a/src/ReportsAsService/ReportClient.php
+++ b/src/ReportsAsService/ReportClient.php
@@ -29,7 +29,7 @@ class ReportClient extends UltiproSoapClient
         try {
             $logonResponse = $this->login();
 
-            $client = $this->buildClient();
+            $client = $this->buildClient($this->getBaseUri(), $this->getOptions());
 
             $headers = [
                 new SoapHeader('http://www.w3.org/2005/08/addressing', 'Action', 'http://www.ultipro.com/dataservices/bidata/2/IBIDataService/GetReportList', true),
@@ -81,7 +81,7 @@ class ReportClient extends UltiproSoapClient
         try {
             $logonResponse = $this->login();
 
-            $client = $this->buildClient();
+            $client = $this->buildClient($this->getBaseUri(), $this->getOptions());
 
             $headers = [
                 new SoapHeader('http://www.w3.org/2005/08/addressing', 'Action', 'http://www.ultipro.com/dataservices/bidata/2/IBIDataService/GetReportParameters', true),
@@ -151,9 +151,7 @@ class ReportClient extends UltiproSoapClient
         try {
             $logonResponse = $this->login();
 
-            $client = $this->buildClient('https://service5.ultipro.com/services/BiDataService', [
-                'US-DELIMITER' => ','
-            ]);
+            $client = $this->buildClient('https://service5.ultipro.com/services/BiDataService', ['US-DELIMITER' => ',']);
 
             $headers = [
                 new SoapHeader('http://www.w3.org/2005/08/addressing', 'Action', 'http://www.ultipro.com/dataservices/bidata/2/IBIDataService/ExecuteReport', true),

--- a/src/UltiproSoapClient.php
+++ b/src/UltiproSoapClient.php
@@ -39,8 +39,8 @@ class UltiproSoapClient
     /** @var LoggerInterface */
     private $logger;
 
-    /** @var SoapClient */
-    private $client;
+    /** @var array */
+    private $options;
 
     /**
      * @param array|Authentication $auth
@@ -53,8 +53,8 @@ class UltiproSoapClient
     public function __construct($auth, string $baseUri = 'https://service5.ultipro.com/services/BIDataService', array $options = [], LoggerInterface $logger = null)
     {
         $this->setAuthentication($auth);
-        $this->client        = $this->buildClient($baseUri, $options);
         $this->baseUri       = $baseUri;
+        $this->options       = $options;
         $this->logger        = $logger;
     }
 
@@ -69,17 +69,19 @@ class UltiproSoapClient
             new SoapHeader('http://www.w3.org/2005/08/addressing', 'To', 'https://service5.ultipro.com/services/BiDataService', true)
         ];
         
-        $this->getClient()->__setSoapHeaders($headers);
+        $client = $this->buildClient($this->baseUri, $this->options);
+        
+        $client->__setSoapHeaders($headers);
 
         try {
-            $response = $this->getClient()->LogOn($this->auth);
+            $response = $client->LogOn($this->auth);
         } catch (Exception $e) {
             $this->getLogger()->error(
                 'There was an error logging into the Ultipro SOAP API',
                 [
                     'message'       => $e->getMessage(),
-                    'last_request'  => $this->getClient()->__getLastRequest(),
-                    'last_response' => $this->getClient()->__getLastResponse()
+                    'last_request'  => $client->__getLastRequest(),
+                    'last_response' => $client->__getLastResponse()
                 ]
             );
 
@@ -90,8 +92,8 @@ class UltiproSoapClient
             $this->getLogger()->error(
                 'There was an error logging into the Ultipro SOAP API',
                 [
-                    'last_request'  => $this->getClient()->__getLastRequest(),
-                    'last_response' => $this->getClient()->__getLastResponse()
+                    'last_request'  => $client->__getLastRequest(),
+                    'last_response' => $client->__getLastResponse()
                 ]
             );
 
@@ -354,10 +356,18 @@ class UltiproSoapClient
     }
 
     /**
-     * @return SoapClient
+     * @return string
      */
-    public function getClient()
+    public function getBaseUri()
     {
-        return $this->client;
+        return $this->baseUri;
+    }
+
+    /**
+     * @return array
+     */
+    public function getOptions()
+    {
+        return $this->options;
     }
 }


### PR DESCRIPTION
No longer build the SOAP Client on every instantiation of UltiproSoapClient. Instead, defer the building of the client by passing baseUri and default options when you actually want to pull data.