### PR TITLE
Updates for PHP 8.4 Deprecations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,8 @@
         "ext-pcre": "*",
         "ext-json": "*",
         "ext-xml": "*",
+        "ext-soap": "*",
+        "ext-simplexml": "*",
         "symfony/property-info": "~3.4|~4.0|~5.0|~6.0|~7.0"
     },
     "require-dev": {

--- a/src/Personnel/Query/EmploymentDetailQuery.php
+++ b/src/Personnel/Query/EmploymentDetailQuery.php
@@ -61,7 +61,7 @@ class EmploymentDetailQuery extends PersonnelQuery
     /**
      * @param string $primaryJobCode
      *
-     * @return EmploymentDetailRequest
+     * @return EmploymentDetailQuery
      */
     public function setPrimaryJobCode(string $primaryJobCode)
     {
@@ -81,7 +81,7 @@ class EmploymentDetailQuery extends PersonnelQuery
     /**
      * @param string $jobTitle
      *
-     * @return EmploymentDetailRequest
+     * @return EmploymentDetailQuery
      */
     public function setJobTitle(string $jobTitle)
     {
@@ -101,7 +101,7 @@ class EmploymentDetailQuery extends PersonnelQuery
     /**
      * @param string $fullTimeOrPartTime
      *
-     * @return EmploymentDetailRequest
+     * @return EmploymentDetailQuery
      */
     public function setFullTimeOrPartTime(string $fullTimeOrPartTime)
     {
@@ -121,7 +121,7 @@ class EmploymentDetailQuery extends PersonnelQuery
     /**
      * @param string $primaryWorkLocationCode
      *
-     * @return EmploymentDetailRequest
+     * @return EmploymentDetailQuery
      */
     public function setPrimaryWorkLocationCode(string $primaryWorkLocationCode)
     {
@@ -141,7 +141,7 @@ class EmploymentDetailQuery extends PersonnelQuery
     /**
      * @param string $primaryProjectCode
      *
-     * @return EmploymentDetailRequest
+     * @return EmploymentDetailQuery
      */
     public function setPrimaryProjectCode(string $primaryProjectCode)
     {
@@ -161,7 +161,7 @@ class EmploymentDetailQuery extends PersonnelQuery
     /**
      * @param string $deductionGroupCode
      *
-     * @return EmploymentDetailRequest
+     * @return EmploymentDetailQuery
      */
     public function setDeductionGroupCode(string $deductionGroupCode)
     {
@@ -181,7 +181,7 @@ class EmploymentDetailQuery extends PersonnelQuery
     /**
      * @param string $earningGroupCode
      *
-     * @return EmploymentDetailRequest
+     * @return EmploymentDetailQuery
      */
     public function setEarningGroupCode(string $earningGroupCode)
     {
@@ -201,7 +201,7 @@ class EmploymentDetailQuery extends PersonnelQuery
     /**
      * @param string $employeeTypeCode
      *
-     * @return EmploymentDetailRequest
+     * @return EmploymentDetailQuery
      */
     public function setEmployeeTypeCode(string $employeeTypeCode)
     {
@@ -221,7 +221,7 @@ class EmploymentDetailQuery extends PersonnelQuery
     /**
      * @param string $employeeStatusCode
      *
-     * @return EmploymentDetailRequest
+     * @return EmploymentDetailQuery
      */
     public function setEmployeeStatusCode(string $employeeStatusCode)
     {
@@ -241,7 +241,7 @@ class EmploymentDetailQuery extends PersonnelQuery
     /**
      * @param string $employeeNumber
      *
-     * @return EmploymentDetailRequest
+     * @return EmploymentDetailQuery
      */
     public function setEmployeeNumber(string $employeeNumber)
     {
@@ -261,7 +261,7 @@ class EmploymentDetailQuery extends PersonnelQuery
     /**
      * @param string $supervisorId
      *
-     * @return EmploymentDetailRequest
+     * @return EmploymentDetailQuery
      */
     public function setSupervisorId(string $supervisorId)
     {

--- a/src/Personnel/Query/PersonDetailQuery.php
+++ b/src/Personnel/Query/PersonDetailQuery.php
@@ -40,7 +40,7 @@ class PersonDetailQuery extends PersonnelQuery
     /**
      * @param string $lastName
      *
-     * @return PersonDetailRequest
+     * @return PersonDetailQuery
      */
     public function setLastName(string $lastName)
     {
@@ -60,7 +60,7 @@ class PersonDetailQuery extends PersonnelQuery
     /**
      * @param string $emailAddress
      *
-     * @return PersonDetailRequest
+     * @return PersonDetailQuery
      */
     public function setEmailAddress(string $emailAddress)
     {
@@ -80,7 +80,7 @@ class PersonDetailQuery extends PersonnelQuery
     /**
      * @param string $addressState
      *
-     * @return PersonDetailRequest
+     * @return PersonDetailQuery
      */
     public function setAddressState(string $addressState)
     {
@@ -100,7 +100,7 @@ class PersonDetailQuery extends PersonnelQuery
     /**
      * @param string $addressCountry
      *
-     * @return PersonDetailRequest
+     * @return PersonDetailQuery
      */
     public function setAddressCountry(string $addressCountry)
     {

--- a/src/Request.php
+++ b/src/Request.php
@@ -40,7 +40,7 @@ class Request implements RequestInterface
      * @param string $method
      * @param string $endPoint
      */
-    public function __construct(string $method = null, string $endPoint = '')
+    public function __construct(?string $method = null, string $endPoint = '')
     {
         $this->method   = $method;
         $this->endPoint = $endPoint;

--- a/src/RequestInterface.php
+++ b/src/RequestInterface.php
@@ -21,11 +21,11 @@ interface RequestInterface
     public function getMethod();
 
     /**
-     * @param string $method
+     * @param string|null $method
      *
      * @return $this
      */
-    public function setMethod(string $method);
+    public function setMethod(?string $method);
 
     /**
      * @return string
@@ -33,11 +33,11 @@ interface RequestInterface
     public function getEndPoint();
 
     /**
-     * @param string $endpoint
+     * @param string $endPoint
      *
      * @return $this
      */
-    public function setEndPoint(string $endpoint);
+    public function setEndPoint(string $endPoint);
 
     /**
      * @return Query

--- a/src/UltiproClient.php
+++ b/src/UltiproClient.php
@@ -54,7 +54,7 @@ class UltiproClient
      *
      * @throws InvalidArgumentException
      */
-    public function __construct($auth, string $baseUri = 'https://service5.ultipro.com/', array $options = [])
+    public function __construct(array|Authentication $auth, string $baseUri = 'https://service5.ultipro.com/', array $options = [])
     {
         $this->setAuthentication($auth);
         $this->baseUri      = $baseUri;
@@ -66,12 +66,12 @@ class UltiproClient
      * @param bool $parseQueryAsArray
      * @param bool $parsePostAsArray
      *
-     * @return mixed|ResponseInterface
+     * @return ResponseInterface
      * @throws ClientException
      * @throws GuzzleException
      * @throws InvalidArgumentException
      */
-    public function get(RequestInterface $request, $parseQueryAsArray = false, $parsePostAsArray = false)
+    public function get(RequestInterface $request, bool $parseQueryAsArray = false, bool $parsePostAsArray = false)
     {
         $options = $this->parseRequest($request, $parseQueryAsArray, $parsePostAsArray);
 
@@ -93,12 +93,12 @@ class UltiproClient
      * @param bool $parseQueryAsArray
      * @param bool $parsePostAsArray
      *
-     * @return mixed|ResponseInterface
+     * @return ResponseInterface
      * @throws ClientException
      * @throws GuzzleException
      * @throws InvalidArgumentException
      */
-    public function post(RequestInterface $request, $parseQueryAsArray = false, $parsePostAsArray = false)
+    public function post(RequestInterface $request, bool $parseQueryAsArray = false, bool $parsePostAsArray = false)
     {
         $options = $this->parseRequest($request, $parseQueryAsArray, $parsePostAsArray);
 
@@ -219,7 +219,7 @@ class UltiproClient
      * @return array
      * @throws InvalidArgumentException
      */
-    protected function parseRequest(RequestInterface $request, $parseQueryAsArray = false, $parsePostAsArray = false)
+    protected function parseRequest(RequestInterface $request, bool $parseQueryAsArray = false, bool $parsePostAsArray = false)
     {
         $queryParameters = $request->getQueryParameters();
         $postParameters  = $request->getPostParameters();
@@ -364,7 +364,6 @@ class UltiproClient
      * @param string $prefix
      *
      * @return array
-     * @throws ReflectionException
      */
     public function getClientEndpoints($prefix = 'ENDPOINT_')
     {


### PR DESCRIPTION
Also removed the LoggerInterface requirement. This library should not have a requirement on monolog outside of Symfony.